### PR TITLE
Allow installation of sahi_general as python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@
         List[dict]
             list of detections for each frame with keys: label, confidence, t, l, b, r, w, h
             
+## Using sahi_general as a package for inference
 
-## Usage 
-- Refer to ```sahi_general_test.py``` for example usage 
+- Clone this repository
+- Make sure the requirements above are installed
+- in the main project folder, install sahi_general as a package
+```
+python3 -m pip install --no-cache-dir /path/to/sahi_general
+```
+OR as an editable package (if you need to make changes to the code, faster to build)
+```
+python3 -m pip install -e /path/to/sahi_general
+```
+- import the sahi_general wrapper class for inference (refer to ```sahi_general_test.py``` for example usage )
+```
+from script.sahi_general import SahiGeneral
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sahi_general"
+version = "1.0"
+
+[tool.setuptools.packages]
+find = {}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup(
+        name="sahi_general",
+        version="1.0",
+        packages=setuptools.find_packages(),
+        install_requires=["sahi"]
+    )


### PR DESCRIPTION
Added `setup.py` and `pyproject.toml` so that sahi_general can be installed and used as a python package

Edited README to include instructions on how to install