### PR TITLE
Remove unused `bool_mask` argument in `ObjectPrediction` call to fix compatibility with newer versions

### DIFF
--- a/script/sahi_general.py
+++ b/script/sahi_general.py
@@ -249,7 +249,6 @@ class SahiGeneral(DetectionModel):
                 bbox=bbox,
                 score=score,
                 category_id = self.model.classname_to_idx(category_name),
-                bool_mask=None,
                 category_name=category_name,
                 shift_amount=shift_amount,
                 full_shape=full_shape,


### PR DESCRIPTION
Removed the `bool_mask=None` argument from the `ObjectPrediction` instantiation in `scripts/sahi_general.py` (line 252). The newer versions of `ObjectPrediction` no longer accept this parameter, causing errors. This update resolves the issue and ensures compatibility.